### PR TITLE
Limit Kucoin to 100 concurrent streams per connection

### DIFF
--- a/src/exchanges/kucoin/ws/builder.rs
+++ b/src/exchanges/kucoin/ws/builder.rs
@@ -10,8 +10,8 @@ use crate::{
 
 /// There is a limit of 300 connections per attempt every 5 minutes per IP.
 const MAX_KUCOIN_STREAMS: usize = 300;
-/// A single connection can listen to a maximum of 1024 streams.
-const MAX_KUCOIN_WS_CONNS_PER_STREAM: usize = 1024;
+/// A single connection can listen to a maximum of 100 streams.
+const MAX_KUCOIN_WS_CONNS_PER_STREAM: usize = 100;
 
 #[derive(Debug, Clone, Default)]
 pub struct KucoinWsBuilder {

--- a/src/exchanges/kucoin/ws/builder.rs
+++ b/src/exchanges/kucoin/ws/builder.rs
@@ -11,7 +11,7 @@ use crate::{
 /// There is a limit of 300 connections per attempt every 5 minutes per IP.
 const MAX_KUCOIN_STREAMS: usize = 300;
 /// A single connection can listen to a maximum of 100 streams.
-const MAX_KUCOIN_WS_CONNS_PER_STREAM: usize = 100;
+pub const MAX_KUCOIN_WS_CONNS_PER_STREAM: usize = 100;
 
 #[derive(Debug, Clone, Default)]
 pub struct KucoinWsBuilder {


### PR DESCRIPTION
Testing revealed that Kucoin is limited to 100 streams per connection.